### PR TITLE
Implement quick settings toggle button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
     <uses-permission
         android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED"
         android:minSdkVersion="34" />
-
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -40,6 +41,20 @@
                 android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
                 android:value="true" />
         </service>
+
+        <service
+            android:name=".QuickStartService"
+            android:exported="true"
+            android:label="Oblivion"
+            android:icon="@drawable/vpn_off"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <meta-data android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+
+    </service>
 
         <activity
             android:name="org.bepass.oblivion.MainActivity"

--- a/app/src/main/java/org/bepass/oblivion/ConnectionState.java
+++ b/app/src/main/java/org/bepass/oblivion/ConnectionState.java
@@ -1,0 +1,7 @@
+package org.bepass.oblivion;
+
+public enum ConnectionState {
+    CONNECTING,
+    CONNECTED,
+    DISCONNECTED
+}

--- a/app/src/main/java/org/bepass/oblivion/ConnectionStateChangeListener.java
+++ b/app/src/main/java/org/bepass/oblivion/ConnectionStateChangeListener.java
@@ -1,0 +1,5 @@
+package org.bepass.oblivion;
+
+public interface ConnectionStateChangeListener {
+    void onChange(ConnectionState state);
+}

--- a/app/src/main/java/org/bepass/oblivion/FileManager.java
+++ b/app/src/main/java/org/bepass/oblivion/FileManager.java
@@ -53,8 +53,15 @@ public class FileManager {
         return sharedPreferences.getString(name, "");
     }
 
+    public String getString(String name, String defaultValue) {
+        return sharedPreferences.getString(name, defaultValue);
+    }
+
     public boolean getBoolean(String name) {
         return sharedPreferences.getBoolean(name, false);
+    }
+    public boolean getBoolean(String name, boolean defaultValue) {
+        return sharedPreferences.getBoolean(name, defaultValue);
     }
 
     public int getInt(String name) {

--- a/app/src/main/java/org/bepass/oblivion/MainActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/MainActivity.java
@@ -1,18 +1,14 @@
 package org.bepass.oblivion;
 
 import android.Manifest;
-import android.app.ActivityManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.IBinder;
-import android.os.Message;
 import android.os.Messenger;
-import android.os.RemoteException;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -24,37 +20,33 @@ import androidx.core.content.ContextCompat;
 
 import com.suke.widget.SwitchButton;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-
-import tun2socks.StartOptions;
-
 public class MainActivity extends AppCompatActivity {
+
+    private static final String ConnectionStateObserverKey = "mainActivity";
     private ActivityResultLauncher<String> pushNotificationPermissionLauncher;
     private ActivityResultLauncher<Intent> vpnPermissionLauncher;
 
     private Messenger serviceMessenger;
     private boolean isBound;
 
-    // 1 Wait For Connect
-    // 2 Connecting
-    // 3 Connected
-    int connectionState = 1;
 
     // Views
     ImageView infoIcon, bugIcon, settingsIcon;
-    SwitchButton switchButton;
+    TouchAwareSwitch switchButton;
     TextView stateText;
 
     FileManager fileManager;
 
     Boolean canShowNotification = false;
 
+    private ConnectionState lastKnownConnectionState = ConnectionState.DISCONNECTED;
+
     private ServiceConnection connection = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName className, IBinder service) {
             serviceMessenger = new Messenger(service);
             isBound = true;
+            observeConnectionStatus();
         }
 
         @Override
@@ -64,25 +56,23 @@ public class MainActivity extends AppCompatActivity {
         }
     };
 
+
     private SwitchButton.OnCheckedChangeListener createSwitchCheckedChangeListener() {
         return (view, isChecked) -> {
             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !canShowNotification) {
                 pushNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
                 return;
             }
-            if (connectionState == 1 && isChecked) {
-                // From NoAction to Connecting
-                stateText.setText("درحال اتصال ...");
-                connectionState = 2;
 
+            if (lastKnownConnectionState == ConnectionState.DISCONNECTED && isChecked) {
+                // From NoAction to Connecting
                 Intent vpnIntent = OblivionVpnService.prepare(this);
                 if (vpnIntent != null) {
                     vpnPermissionLauncher.launch(vpnIntent);
                 } else {
                     startVpnService();
                 }
-            } else if(connectionState < 4 && connectionState > 1) {
-                disconnected();
+            } else if(lastKnownConnectionState == ConnectionState.CONNECTED || lastKnownConnectionState == ConnectionState.CONNECTING) {
                 stopVpnService();
             }
         };
@@ -92,39 +82,39 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
         init();
         firstValueInit();
-        if(isMyServiceRunning()) {
-            connected();
-        }
         switchButton.setOnCheckedChangeListener(createSwitchCheckedChangeListener());
     }
 
-    private void sendMessageToService() {
+
+
+    private void observeConnectionStatus() {
         if (!isBound) return;
-        try {
-            // Create a message for the service
-            Message msg = Message.obtain(null, OblivionVpnService.MSG_PERFORM_TASK);
+        OblivionVpnService.registerConnectionStateObserver(ConnectionStateObserverKey, serviceMessenger, new ConnectionStateChangeListener() {
+            @Override
+            public void onChange(ConnectionState state) {
+                lastKnownConnectionState = state;
+                updateUi();
+            }
+        });
+    }
 
-            // Create a Messenger for the reply from the service
-            Messenger replyMessenger = new Messenger(new Handler(message -> {
-                if (message.what == OblivionVpnService.MSG_TASK_COMPLETED) {
-                    // Handle task completion
-                    Toast.makeText(getApplicationContext(), "متصل شدید!", Toast.LENGTH_LONG).show();
-                    connected();
-                } else {
-                    disconnected();
-                    stopVpnService();
-                }
-                return true;
-            }));
-            msg.replyTo = replyMessenger;
-
-            // Send the message
-            serviceMessenger.send(msg);
-        } catch (RemoteException e) {
-            e.printStackTrace();
+    private void unsubscribeConnectionStatus() {
+        if (!isBound) return;
+        OblivionVpnService.unregisterConnectionStateObserver(ConnectionStateObserverKey, serviceMessenger);
+    }
+    private void updateUi() {
+        switch(lastKnownConnectionState) {
+            case DISCONNECTED:
+                disconnected();
+                break;
+            case CONNECTING:
+                connecting();
+                break;
+            case CONNECTED:
+                connected();
+                break;
         }
     }
 
@@ -140,26 +130,25 @@ public class MainActivity extends AppCompatActivity {
         super.onStop();
         // Unbind from the service
         if (isBound) {
+            unsubscribeConnectionStatus();
             unbindService(connection);
             isBound = false;
         }
     }
 
     private void connected() {
-        switchButton.setOnCheckedChangeListener(null);
         stateText.setText("اتصال برقرار شد");
-        connectionState = 3;
-        switchButton.setChecked(true);
-        switchButton.setOnCheckedChangeListener(createSwitchCheckedChangeListener());
+        switchButton.setChecked(true, false);
+    }
+
+    private void connecting() {
+        stateText.setText("در حال اتصال...");
+        switchButton.setChecked(true, false);
     }
 
     private void disconnected() {
-        switchButton.setOnCheckedChangeListener(null);
-        // From Connecting to Disconnecting
         stateText.setText("متصل نیستید");
-        connectionState = 1;
-        switchButton.setChecked(false);
-        switchButton.setOnCheckedChangeListener(createSwitchCheckedChangeListener());
+        switchButton.setChecked(false, false);
     }
 
     private void firstValueInit() {
@@ -192,69 +181,19 @@ public class MainActivity extends AppCompatActivity {
                     if (result.getResultCode() == RESULT_OK) {
                         startVpnService();
                     } else {
+                        stopVpnService();
                         Toast.makeText(this, "Really!?", Toast.LENGTH_LONG).show();
                     }
                 }
         );
     }
 
-    private boolean isMyServiceRunning() {
-        ActivityManager manager = (ActivityManager) getSystemService(ACTIVITY_SERVICE);
-        if (manager != null) {
-            for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
-                if (OblivionVpnService.class.getName().equals(service.service.getClassName())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private static int findFreePort() {
-        ServerSocket socket = null;
-        try {
-            socket = new ServerSocket(0);
-            socket.setReuseAddress(true);
-            int port = socket.getLocalPort();
-            try {
-                socket.close();
-            } catch (IOException e) {
-                // Ignore IOException on close()
-            }
-            return port;
-        } catch (IOException e) {
-        } finally {
-            if (socket != null) {
-                try {
-                    socket.close();
-                } catch (IOException e) {
-                }
-            }
-        }
-        throw new IllegalStateException("Could not find a free TCP/IP port to start embedded Jetty HTTP Server on");
-    }
-
-    private String getBindAddress() {
-        String port = fileManager.getString("USERSETTING_port");
-        boolean enableLan = fileManager.getBoolean("USERSETTING_lan");
-        if(OblivionVpnService.isLocalPortInUse("127.0.0.1:" + port).equals("true")) {
-            port = findFreePort()+"";
-        }
-        String Bind = "";
-        Bind += "127.0.0.1:" + port;
-        if(enableLan) {
-            Bind = "0.0.0.0:" + port;
-        }
-        return Bind;
-    }
 
     private void startVpnService() {
         //Toast.makeText(getApplicationContext(), calculateArgs(), Toast.LENGTH_LONG).show();
         Intent intent = new Intent(this, OblivionVpnService.class);
-        intent.putExtra("bindAddress", getBindAddress());
         intent.setAction(OblivionVpnService.FLAG_VPN_START);
         ContextCompat.startForegroundService(this, intent);
-        sendMessageToService();
     }
 
     private void stopVpnService() {

--- a/app/src/main/java/org/bepass/oblivion/QuickStartService.java
+++ b/app/src/main/java/org/bepass/oblivion/QuickStartService.java
@@ -1,0 +1,128 @@
+package org.bepass.oblivion;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.graphics.drawable.Icon;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.Messenger;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+import android.widget.Toast;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.content.ContextCompat;
+
+@RequiresApi(api = Build.VERSION_CODES.N)
+public class QuickStartService extends TileService  {
+    private boolean isBound;
+    private Messenger serviceMessenger;
+
+    private final static String CONNECTION_OBSERVER_KEY = "quickstartToggleButton";
+
+    private ServiceConnection connection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            serviceMessenger = new Messenger(service);
+            isBound = true;
+            subscribe();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            serviceMessenger = null;
+            isBound = false;
+        }
+    };
+
+
+
+    // Called when your app can update your tile.
+    @Override
+    public void onStartListening() {
+        bindService(new Intent(this, OblivionVpnService.class), connection, Context.BIND_AUTO_CREATE);
+    }
+
+    // Called when your app can no longer update your tile.
+    @Override
+    public void onStopListening() {
+        // Unbind from the service
+        if (isBound) {
+            unsubscribe();
+            isBound = false;
+        }
+        try {
+            unbindService(connection);
+        } catch (Exception e) {
+            //Swallow unbound unbind exceptions
+        }
+    }
+
+    // Called when the user taps on your tile in an active or inactive state.
+    @Override
+    public void onClick() {
+        Tile tile = getQsTile();
+        if (tile.getState() == Tile.STATE_INACTIVE) {
+            Intent vpnIntent = OblivionVpnService.prepare(this);
+            if (vpnIntent != null) {
+                Toast.makeText(this, "لطفا یک‌بار از درون اپلیکیشن متصل شوید", Toast.LENGTH_LONG).show();
+            } else {
+                startVpnService();
+            }
+        } else {
+            stopVpnService();
+        }
+    }
+
+
+    private void startVpnService() {
+        //Toast.makeText(getApplicationContext(), calculateArgs(), Toast.LENGTH_LONG).show();
+        Intent intent = new Intent(this, OblivionVpnService.class);
+        intent.setAction(OblivionVpnService.FLAG_VPN_START);
+        ContextCompat.startForegroundService(this, intent);
+    }
+
+
+    private void stopVpnService() {
+        Intent intent = new Intent(this, OblivionVpnService.class);
+        intent.setAction(OblivionVpnService.FLAG_VPN_STOP);
+        ContextCompat.startForegroundService(this, intent);
+    }
+
+    private void subscribe() {
+        if (!isBound) return;
+        OblivionVpnService.registerConnectionStateObserver(CONNECTION_OBSERVER_KEY, serviceMessenger, new ConnectionStateChangeListener() {
+            @Override
+            public void onChange(ConnectionState state) {
+                Tile tile = getQsTile();
+                switch (state) {
+                    case DISCONNECTED:
+                        tile.setState(Tile.STATE_INACTIVE);
+                        tile.setLabel("Oblivion");
+                        tile.setIcon(Icon.createWithResource(getApplicationContext(), R.drawable.vpn_off));
+                        tile.updateTile();
+                        break;
+                    case CONNECTING:
+                        tile.setState(Tile.STATE_ACTIVE);
+                        tile.setLabel("Connecting");
+                        tile.setIcon(Icon.createWithResource(getApplicationContext(), R.drawable.vpn_off));
+                        tile.updateTile();
+                        break;
+                    case CONNECTED:
+                        tile.setState(Tile.STATE_ACTIVE);
+                        tile.setLabel("Connected");
+                        tile.setIcon(Icon.createWithResource(getApplicationContext(), R.drawable.vpn_on));
+                        tile.updateTile();
+                }
+            }
+        });
+    }
+
+    private void unsubscribe() {
+        if (!isBound) return;
+        OblivionVpnService.unregisterConnectionStateObserver(CONNECTION_OBSERVER_KEY, serviceMessenger);
+    }
+
+}

--- a/app/src/main/java/org/bepass/oblivion/TouchAwareSwitch.java
+++ b/app/src/main/java/org/bepass/oblivion/TouchAwareSwitch.java
@@ -1,0 +1,51 @@
+package org.bepass.oblivion;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.suke.widget.SwitchButton;
+
+public class TouchAwareSwitch extends SwitchButton {
+
+    public TouchAwareSwitch(Context context) {
+        super(context);
+    }
+
+    public TouchAwareSwitch(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public TouchAwareSwitch(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    public void setOnCheckedChangeListener(final OnCheckedChangeListener listener) {
+        setOnTouchListener((v, event) -> {
+            setTag(null);
+            return false;
+        });
+
+        super.setOnCheckedChangeListener((view, isChecked) -> {
+            if (getTag() != null) {
+                setTag(null);
+                return;
+            }
+            listener.onCheckedChanged(view, isChecked);
+        });
+    }
+
+    public void setChecked(boolean checked, boolean notify) {
+        if (!notify) setTag("TAG");
+        setChecked(checked);
+    }
+
+
+
+
+
+
+}

--- a/app/src/main/res/drawable/vpn_off.xml
+++ b/app/src/main/res/drawable/vpn_off.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20.83,18H21v-4h2v-4H12.83L20.83,18zM19.78,22.61l1.41,-1.41L2.81,2.81L1.39,4.22l2.59,2.59C2.2,7.85 1,9.79 1,12c0,3.31 2.69,6 6,6c2.21,0 4.15,-1.2 5.18,-2.99L19.78,22.61zM8.99,11.82C9,11.88 9,11.94 9,12c0,1.1 -0.9,2 -2,2s-2,-0.9 -2,-2s0.9,-2 2,-2c0.06,0 0.12,0 0.18,0.01L8.99,11.82z"/>
+</vector>

--- a/app/src/main/res/drawable/vpn_on.xml
+++ b/app/src/main/res/drawable/vpn_on.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12.65,10C11.83,7.67 9.61,6 7,6c-3.31,0 -6,2.69 -6,6s2.69,6 6,6c2.61,0 4.83,-1.67 5.65,-4H17v4h4v-4h2v-4H12.65zM7,14c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -64,7 +64,7 @@
     </LinearLayout>
 
 
-    <com.suke.widget.SwitchButton
+    <org.bepass.oblivion.TouchAwareSwitch
         android:id="@+id/switch_button"
         android:layout_width="160dp"
         android:layout_height="75dp"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-id 'com.android.application' version '8.1.2' apply false
+    id 'com.android.application' version '8.1.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 }


### PR DESCRIPTION
This pull request introduces a new feature to Oblivion – Quick Settings Connection Toggle Button.
Quick Settings or Tile Buttons, provide users with convenient access to easily connect or disconnect through notification panel without opening the app itself.
**MainActivity and ObvilionVpnService classes were heavily refactored.** The notification tile button needed to be in sync with MainActivity button. They're now using observer pattern done through message passing. 
The connection state now resides inside ObvilionVpnService and other components interested in connection status can observe it by registering an observer. This is done to have a single "source-of-truth" for the connection state.
The new pattern is tested on several Samsung devices running Android 11-14  and works perfectly. However this is Android's world. A feature working great on a phone might work terrible on another OEM. I think it's better to have it tested on other OEMs too.

![photo_2024-02-12_06-27-48](https://github.com/bepass-org/oblivion/assets/75689502/a13a16cc-af43-4ac2-ae5a-3f1ad44058a9)
![photo_2024-02-12_06-27-51](https://github.com/bepass-org/oblivion/assets/75689502/f28e897b-e76e-4126-8d95-1aff4bc905d4)
