### PR TITLE
Using Spinner(Drop-Down List) instead of TextView(Input) for Psiphon Country

### DIFF
--- a/app/src/main/java/org/bepass/oblivion/CountryUtils.java
+++ b/app/src/main/java/org/bepass/oblivion/CountryUtils.java
@@ -1,0 +1,23 @@
+package org.bepass.oblivion;
+
+import java.util.Locale;
+
+public class CountryUtils {
+
+    public static String getCountryCode(String name) {
+        for (String code : Locale.getISOCountries()) {
+            Locale locale = new Locale("", code);
+            if (locale.getDisplayCountry().equalsIgnoreCase(name)) {
+                return code;
+            }
+        }
+
+        return "";
+    }
+
+    public static String getCountryName(String code) {
+        Locale locale = new Locale("", code);
+        return locale.getDisplayCountry();
+    }
+
+}

--- a/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
@@ -4,9 +4,13 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import org.bepass.oblivion.R;
@@ -18,8 +22,10 @@ public class SettingsActivity extends AppCompatActivity {
 
     LinearLayout endpointLayout, portLayout, lanLayout, psiphonLayout, countryLayout, licenseLayout, goolLayout;
 
-    TextView endpoint, port, country, license;
+    TextView endpoint, port, license;
     CheckBox psiphon, lan, gool;
+    Spinner country;
+    ArrayAdapter adapter;
 
     private CheckBox.OnCheckedChangeListener psiphonListener;
     private CheckBox.OnCheckedChangeListener goolListener;
@@ -41,8 +47,25 @@ public class SettingsActivity extends AppCompatActivity {
         // Listen to Changes
         endpointLayout.setOnClickListener(v -> (new EditSheet(this, "اندپوینت", "endpoint", sheetsCallBack)).start());
         portLayout.setOnClickListener(v -> (new EditSheet(this, "پورت", "port", sheetsCallBack)).start());
-        countryLayout.setOnClickListener(v -> (new EditSheet(this, "کشور", "country", sheetsCallBack)).start());
         licenseLayout.setOnClickListener(v -> (new EditSheet(this, "لایسنس", "license", sheetsCallBack)).start());
+
+        adapter = ArrayAdapter.createFromResource(this, R.array.countries, R.layout.country_item_layout);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        country.setAdapter(adapter);
+
+        country.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView parent, View view, int position, long id) {
+                String name = parent.getItemAtPosition(position).toString();
+                String code = CountryUtils.getCountryCode(name);
+                fileManager.set("USERSETTING_country", code);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView parent) {
+
+            }
+        });
 
         // Set Current Values
         settingBasicValuesFromSPF();
@@ -60,7 +83,7 @@ public class SettingsActivity extends AppCompatActivity {
                 fileManager.set("USERSETTING_gool", false);
             }
             countryLayout.setAlpha(isChecked ? 1f : 0.2f);
-            countryLayout.setClickable(isChecked);
+            country.setEnabled(isChecked);
         };
 
         goolListener = (buttonView, isChecked) -> {
@@ -69,7 +92,7 @@ public class SettingsActivity extends AppCompatActivity {
                 setCheckBoxWithoutTriggeringListener(psiphon, false, psiphonListener);
                 fileManager.set("USERSETTING_psiphon", false);
                 countryLayout.setAlpha(0.2f);
-                countryLayout.setClickable(false);
+                country.setEnabled(false);
             }
         };
 
@@ -78,11 +101,31 @@ public class SettingsActivity extends AppCompatActivity {
         gool.setOnCheckedChangeListener(goolListener);
     }
 
+    private int getIndexFromName(Spinner spinner, String name) {
+
+        for (int i = 0; i < spinner.getCount(); i++) {
+            if (spinner.getItemAtPosition(i).toString().equals(name)) {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
     private void settingBasicValuesFromSPF() {
         endpoint.setText(fileManager.getString("USERSETTING_endpoint"));
         port.setText(fileManager.getString("USERSETTING_port"));
-        country.setText(fileManager.getString("USERSETTING_country"));
         license.setText(fileManager.getString("USERSETTING_license"));
+
+        String countryCode = fileManager.getString("USERSETTING_country");
+        int index;
+        if("".equals(countryCode)) {
+            index = 0;
+        } else {
+            String countryName = CountryUtils.getCountryName(countryCode);
+            index = getIndexFromName(country, countryName);
+        }
+        country.setSelection(index);
 
         psiphon.setChecked(fileManager.getBoolean("USERSETTING_psiphon"));
         lan.setChecked(fileManager.getBoolean("USERSETTING_lan"));
@@ -91,10 +134,10 @@ public class SettingsActivity extends AppCompatActivity {
 
         if (!psiphon.isChecked()) {
             countryLayout.setAlpha(0.2f);
-            countryLayout.setClickable(false);
+            country.setEnabled(false);
         } else {
             countryLayout.setAlpha(1f);
-            countryLayout.setClickable(true);
+            country.setEnabled(true);
         }
     }
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -305,22 +305,17 @@
                     android:layout_height="wrap_content"
                     android:gravity="end">
 
-                    <TextView
+                    <Spinner
                         android:id="@+id/country"
-                        android:layout_width="0dp"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_weight="2"
-                        android:fontFamily="@font/shabnammedium"
-                        android:text="Iran"
-                        android:maxLines="1"
-                        android:ellipsize="end"
-                        android:textColor="#E4AB53"
-                        android:textSize="20sp" />
+                        android:layout_weight="1"/>
                     
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:minWidth="100dp"
+                        android:layout_marginStart="40dp"
                         android:fontFamily="@font/shabnam"
                         android:text="انتخاب کشور"
                         android:textColor="@color/black"

--- a/app/src/main/res/layout/country_item_layout.xml
+++ b/app/src/main/res/layout/country_item_layout.xml
@@ -1,0 +1,7 @@
+<!-- spinner_item_layout.xml -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="5dp"
+    android:textSize="18sp"
+    android:fontFamily="@font/shabnammedium" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,35 @@
 <resources>
     <string name="app_name">Oblivion</string>
+    <string-array name="countries">
+        <item>Automatic</item>
+        <item>Austria</item>
+        <item>Belgium</item>
+        <item>Brazil</item>
+        <item>Bulgaria</item>
+        <item>Canada</item>
+        <item>Denmark</item>
+        <item>Estonia</item>
+        <item>Finland</item>
+        <item>France</item>
+        <item>Germany</item>
+        <item>Hungary</item>
+        <item>India</item>
+        <item>Ireland</item>
+        <item>Italy</item>
+        <item>Japan</item>
+        <item>Latvia</item>
+        <item>Netherlands</item>
+        <item>Norway</item>
+        <item>Poland</item>
+        <item>Romania</item>
+        <item>Serbia</item>
+        <item>Singapore</item>
+        <item>Slovakia</item>
+        <item>Spain</item>
+        <item>Sweden</item>
+        <item>Switzerland</item>
+        <item>Ukraine</item>
+        <item>United Kingdom</item>
+        <item>United States</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
This PR replaced a TextView with a Spinner (drop-down list) for choosing Psiphon country. Previously, users had to manually enter country codes, but with these changes, countries are now listed in a dropdown menu. This enhancement allows users to easily select their desired country without the hassle and confusion of manual entry.
![Screenshot_20240219_194843](https://github.com/bepass-org/oblivion/assets/160499835/8b0d1dab-a79e-47da-b3f2-c56157da5ebc) 
![Screenshot_20240219_194913](https://github.com/bepass-org/oblivion/assets/160499835/95cae540-7a87-4f25-82b7-da7583f83b4a)


