### PR TITLE
VpnService improvements

### DIFF
--- a/app/src/main/java/org/bepass/oblivion/ConnectionAwareBaseActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/ConnectionAwareBaseActivity.java
@@ -1,0 +1,72 @@
+package org.bepass.oblivion;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+import android.os.Messenger;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+
+/**
+ * Those activities that inherit this class observe connection state by default and have access to lastKnownConnectionState variable.
+ */
+public abstract class ConnectionAwareBaseActivity extends AppCompatActivity {
+
+    protected ConnectionState lastKnownConnectionState = ConnectionState.DISCONNECTED;
+
+    private Messenger serviceMessenger;
+    private boolean isBound;
+
+    private ServiceConnection connection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            serviceMessenger = new Messenger(service);
+            isBound = true;
+            observeConnectionStatus();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            serviceMessenger = null;
+            isBound = false;
+        }
+    };
+
+    abstract String getKey();
+    abstract void onConnectionStateChange(ConnectionState state);
+
+    private void observeConnectionStatus() {
+        if (!isBound) return;
+        OblivionVpnService.registerConnectionStateObserver(getKey(), serviceMessenger, state -> {
+            lastKnownConnectionState = state;
+            onConnectionStateChange(state);
+        });
+    }
+
+    private void unsubscribeConnectionStatus() {
+        if (!isBound) return;
+        OblivionVpnService.unregisterConnectionStateObserver(getKey(), serviceMessenger);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        // Bind to the service
+        bindService(new Intent(this, OblivionVpnService.class), connection, Context.BIND_AUTO_CREATE);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        // Unbind from the service
+        if (isBound) {
+            unsubscribeConnectionStatus();
+            unbindService(connection);
+            isBound = false;
+        }
+    }
+
+}

--- a/app/src/main/java/org/bepass/oblivion/QuickStartService.java
+++ b/app/src/main/java/org/bepass/oblivion/QuickStartService.java
@@ -61,6 +61,10 @@ public class QuickStartService extends TileService {
     @Override
     public void onClick() {
         Tile tile = getQsTile();
+        if (tile == null) {
+            //Quick setting tile was not registered by system. Return to prevent crash
+            return;
+        }
         if (tile.getState() == Tile.STATE_INACTIVE) {
             Intent vpnIntent = OblivionVpnService.prepare(this);
             if (vpnIntent != null) {
@@ -94,6 +98,10 @@ public class QuickStartService extends TileService {
             @Override
             public void onChange(ConnectionState state) {
                 Tile tile = getQsTile();
+                if (tile == null) {
+                    //Quick setting tile was not registered by system. Return to prevent crash
+                    return;
+                }
                 switch (state) {
                     case DISCONNECTED:
                         tile.setState(Tile.STATE_INACTIVE);

--- a/app/src/main/java/org/bepass/oblivion/QuickStartService.java
+++ b/app/src/main/java/org/bepass/oblivion/QuickStartService.java
@@ -70,26 +70,11 @@ public class QuickStartService extends TileService {
             if (vpnIntent != null) {
                 Toast.makeText(this, "لطفا یک‌بار از درون اپلیکیشن متصل شوید", Toast.LENGTH_LONG).show();
             } else {
-                startVpnService();
+                OblivionVpnService.startVpnService(this);
             }
         } else {
-            stopVpnService();
+            OblivionVpnService.stopVpnService(this);
         }
-    }
-
-
-    private void startVpnService() {
-        //Toast.makeText(getApplicationContext(), calculateArgs(), Toast.LENGTH_LONG).show();
-        Intent intent = new Intent(this, OblivionVpnService.class);
-        intent.setAction(OblivionVpnService.FLAG_VPN_START);
-        ContextCompat.startForegroundService(this, intent);
-    }
-
-
-    private void stopVpnService() {
-        Intent intent = new Intent(this, OblivionVpnService.class);
-        intent.setAction(OblivionVpnService.FLAG_VPN_STOP);
-        ContextCompat.startForegroundService(this, intent);
     }
 
     private void subscribe() {


### PR DESCRIPTION
Made some improvements to the connection state handling. Current connection state was being published to every registered observer whenever a new observer was being registered due to an oversight.

Created a base activity that observes connection state. This is done to prevent service binding logic duplication in every single activity.