### PR TITLE
Fix premature psiphon CONNECTED state

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,5 +52,6 @@ dependencies {
     implementation 'com.github.zcweng:switch-button:0.0.3@aar'
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'com.github.bumptech.glide:glide:4.16.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'])
 }

--- a/app/src/main/java/org/bepass/oblivion/ConnectionAwareBaseActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/ConnectionAwareBaseActivity.java
@@ -41,6 +41,7 @@ public abstract class ConnectionAwareBaseActivity extends AppCompatActivity {
     private void observeConnectionStatus() {
         if (!isBound) return;
         OblivionVpnService.registerConnectionStateObserver(getKey(), serviceMessenger, state -> {
+            if (lastKnownConnectionState == state) return;
             lastKnownConnectionState = state;
             onConnectionStateChange(state);
         });


### PR DESCRIPTION
When using Psiphon mode, the local port (default 8086) is opened before psiphon is actually connected. This confuses OblivionVpnService into thinking the connection is made, publishing invalid CONNECTED state too early. This PR implements a method to wait for psiphon to completely connect, then publish CONNECTED state.