### PR TITLE
Add ability to disable battery optimization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
@@ -134,14 +134,11 @@ public class SettingsActivity extends AppCompatActivity {
     private void ignoreBatteryOptimization() {
         Intent intent = new Intent();
         String packageName = getPackageName();
-        PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-        if (pm != null && !pm.isIgnoringBatteryOptimizations(packageName)) {
+        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        if (powerManager != null) {
             intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
             intent.setData(Uri.parse("package:" + packageName));
             batteryOptimizationLauncher.launch(intent);
-        } else {
-            batteryLayout.setVisibility(View.GONE);
-            batteryDivider.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
@@ -134,12 +134,9 @@ public class SettingsActivity extends AppCompatActivity {
     private void ignoreBatteryOptimization() {
         Intent intent = new Intent();
         String packageName = getPackageName();
-        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
-        if (powerManager != null) {
-            intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
-            intent.setData(Uri.parse("package:" + packageName));
-            batteryOptimizationLauncher.launch(intent);
-        }
+        intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+        intent.setData(Uri.parse("package:" + packageName));
+        batteryOptimizationLauncher.launch(intent);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -546,7 +546,7 @@
               android:layout_height="wrap_content"
               android:minWidth="100dp"
               android:fontFamily="@font/shabnam"
-              android:text="بهینه‌ساز باطری"
+              android:text="بهینه‌ساز باتری"
               android:textColor="@color/black"
               android:textSize="20sp" />
 
@@ -556,7 +556,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="@font/shabnam"
-            android:text="غیرفعال‌سازی بهینه‌ساز باطری جهت اجرا در پس‌زمینه"
+            android:text="غیرفعال‌سازی بهینه‌ساز باتری جهت اجرا در پس‌زمینه"
             android:textColor="#9A9A9A"
             android:textSize="16sp" />
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -497,6 +497,70 @@
           android:textSize="16sp" />
 
       </LinearLayout>
+
+      <LinearLayout
+          android:id="@+id/battery_layout_divider"
+          android:layout_width="match_parent"
+          android:layout_height="10dp"
+          android:gravity="center"
+          android:orientation="vertical"
+          >
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray" />
+      </LinearLayout>
+
+      <LinearLayout
+          android:id="@+id/battery_layout"
+          android:layout_width="match_parent"
+          android:layout_height="80dp"
+          android:gravity="center"
+          android:layout_marginHorizontal="16dp"
+          android:visibility="gone"
+          android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+          <LinearLayout
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_weight="2"
+              >
+
+            <Button
+                android:id="@+id/battery"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:backgroundTint="#E4AB53"
+                android:fontFamily="@font/shabnam"
+                android:textColor="@color/black"
+                android:textSize="16sp"
+                android:text="غیرفعال‌سازی" />
+          </LinearLayout>
+
+          <TextView
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:minWidth="100dp"
+              android:fontFamily="@font/shabnam"
+              android:text="بهینه‌ساز باطری"
+              android:textColor="@color/black"
+              android:textSize="20sp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/shabnam"
+            android:text="غیرفعال‌سازی بهینه‌ساز باطری جهت اجرا در پس‌زمینه"
+            android:textColor="#9A9A9A"
+            android:textSize="16sp" />
+
+      </LinearLayout>
     </LinearLayout>
   </ScrollView>
 


### PR DESCRIPTION
I added the ability for the app to prompt the user to disable battery optimization, if it is not already disabled. This is to ensure the VPN service can run optimally without being restricted.

However, it is important to note that use of REQUEST_IGNORE_BATTERY_OPTIMIZATIONS violates Google Play's policy unless it is absolutely necessary:
https://developer.android.com/training/monitoring-device-state/doze-standby.html

When uploading the app to the Play Store, they will ask why this permission is required. A justification will need to be provided detailing why battery optimization must be disabled for the VPN to function properly.

![Screenshot_20240223_153133](https://github.com/bepass-org/oblivion/assets/160499835/fc1abfaa-e2af-4246-a7ba-21288fba5481)
