### PR TITLE
Fix issue #77 - Location change bug

### DIFF
--- a/app/src/main/java/org/bepass/oblivion/CountryUtils.java
+++ b/app/src/main/java/org/bepass/oblivion/CountryUtils.java
@@ -3,21 +3,18 @@ package org.bepass.oblivion;
 import java.util.Locale;
 
 public class CountryUtils {
-
     public static String getCountryCode(String name) {
         for (String code : Locale.getISOCountries()) {
-            Locale locale = new Locale("", code);
-            if (locale.getDisplayCountry().equalsIgnoreCase(name)) {
+            Locale locale = new Locale("en", code); // Set the language to English
+            if (locale.getDisplayCountry(Locale.ENGLISH).equalsIgnoreCase(name)) {
                 return code;
             }
         }
-
         return "";
     }
 
     public static String getCountryName(String code) {
-        Locale locale = new Locale("", code);
-        return locale.getDisplayCountry();
+        Locale locale = new Locale("en", code); // Set the language to English
+        return locale.getDisplayCountry(Locale.ENGLISH);
     }
-
 }


### PR DESCRIPTION
**Pull Request Description**

Fix for Issue #77 - Location Change Bug
This pull request addresses the issue where the Psiphon location change functionality in the app is not working correctly.

**Issue Summary**
The cause of this issue is the device's language setting. When the device's language is not set to English, the app is unable to retrieve the correct country name and code, leading to the location change problem.

**Proposed Solution**
To fix this issue, we have modified the CountryUtils class to explicitly set the locale to English when retrieving the country name and code. This ensures that the country information is always retrieved in English, regardless of the device's language setting.

**Changes Made**
In the getCountryCode method, we now create a new Locale instance with the language set to "en" (English) and the country code from the loop. Then, we use locale.getDisplayCountry(Locale.ENGLISH) to retrieve the country name in English and compare it with the input name parameter.
In the getCountryName method, we create a new Locale instance with the language set to "en" (English) and the provided code. Then, we use locale.getDisplayCountry(Locale.ENGLISH) to retrieve the country name in English.