### PR TITLE
Add ability to disable battery optimization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />
@@ -95,6 +96,10 @@
 
         <activity
             android:name=".SplitTunnelActivity"
+            android:exported="false" />
+
+        <activity
+            android:name=".BatteryManagementActivity"
             android:exported="false" />
     </application>
 

--- a/app/src/main/java/org/bepass/oblivion/BatteryManagementActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/BatteryManagementActivity.java
@@ -1,0 +1,89 @@
+package org.bepass.oblivion;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Color;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.PowerManager;
+import android.provider.Settings;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class BatteryManagementActivity extends AppCompatActivity {
+
+    private PowerManager powerManager;
+    private String packageName;
+    private Button battery;
+    private TextView batteryStatus;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_battery_management);
+        powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        packageName = getPackageName();
+        batteryStatus = findViewById(R.id.battery_current_status);
+        battery = findViewById(R.id.battery_button);
+        ImageView back = findViewById(R.id.back);
+        Button manual = findViewById(R.id.battery_manual);
+
+        checkOptimizationStatus();
+        manual.setOnClickListener(v -> openURL());
+        back.setOnClickListener(v -> getOnBackPressedDispatcher().onBackPressed());
+
+    }
+
+    private void checkOptimizationStatus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (powerManager.isIgnoringBatteryOptimizations(packageName)) {
+                battery.setText("فعال‌سازی");
+                batteryStatus.setText("غیرفعال است");
+                batteryStatus.setTextColor(Color.parseColor("#29862D"));
+                battery.setOnClickListener(v -> enableBatteryOptimization());
+            } else {
+                battery.setText("غیرفعال‌سازی");
+                batteryStatus.setText("فعال است");
+                batteryStatus.setTextColor(Color.parseColor("#E4AB53"));
+                battery.setOnClickListener(v -> disableBatteryOptimization());
+            }
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @SuppressLint("BatteryLife")
+    private void disableBatteryOptimization() {
+        Intent intent = new Intent();
+        String packageName = getPackageName();
+        intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+        intent.setData(Uri.parse("package:" + packageName));
+        batteryOptimizationLauncher.launch(intent);
+
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private void enableBatteryOptimization() {
+        Intent intent = new Intent();
+        intent.setAction(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+        batteryOptimizationLauncher.launch(intent);
+    }
+
+    private final ActivityResultLauncher<Intent> batteryOptimizationLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> checkOptimizationStatus());
+
+    protected void openURL() {
+        Uri uri = Uri.parse("https://dontkillmyapp.com");
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        startActivity(intent);
+    }
+
+}

--- a/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
+++ b/app/src/main/java/org/bepass/oblivion/SettingsActivity.java
@@ -18,7 +18,7 @@ public class SettingsActivity extends AppCompatActivity {
     FileManager fileManager;
     ImageView back;
 
-    LinearLayout endpointLayout, portLayout, lanLayout, psiphonLayout, countryLayout, licenseLayout, goolLayout, splitTunnelLayout;
+    LinearLayout endpointLayout, portLayout, lanLayout, psiphonLayout, countryLayout, licenseLayout, goolLayout, splitTunnelLayout, batteryLayout;
 
     TextView endpoint, port, license;
     CheckBox psiphon, lan, gool;
@@ -73,6 +73,8 @@ public class SettingsActivity extends AppCompatActivity {
         goolLayout.setOnClickListener(v -> gool.setChecked(!gool.isChecked()));
         lanLayout.setOnClickListener(v -> lan.setChecked(!lan.isChecked()));
         psiphonLayout.setOnClickListener(v -> psiphon.setChecked(!psiphon.isChecked()));
+        batteryLayout.setOnClickListener(v -> startActivity(new Intent(this, BatteryManagementActivity.class)));
+
 
         lan.setOnCheckedChangeListener((buttonView, isChecked) -> fileManager.set("USERSETTING_lan", isChecked));
         // Initialize the listeners
@@ -151,6 +153,7 @@ public class SettingsActivity extends AppCompatActivity {
         countryLayout = findViewById(R.id.country_layout);
         licenseLayout = findViewById(R.id.license_layout);
         goolLayout = findViewById(R.id.gool_layout);
+        batteryLayout = findViewById(R.id.battery_layout);
 
         back = findViewById(R.id.back);
         endpoint = findViewById(R.id.endpoint);

--- a/app/src/main/res/drawable/button_background.xml
+++ b/app/src/main/res/drawable/button_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners  android:radius="25dp"/>
+    <solid android:color="#E4AB53"></solid>
+    <padding
+        android:left="16dp"
+        android:right="16dp" />
+</shape>

--- a/app/src/main/res/layout/activity_battery_management.xml
+++ b/app/src/main/res/layout/activity_battery_management.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/background_gradient"
+    android:orientation="vertical"
+    tools:context="org.bepass.oblivion.BatteryManagementActivity">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginTop="8dp">
+
+        <ImageView
+            android:id="@+id/back"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:layout_marginStart="16dp"
+            android:src="@drawable/ic_back"
+            app:tint="#000000" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="@font/shabnamlight"
+            android:text="بهینه‌ساز باتری"
+            android:textColor="@color/black"
+            android:textSize="24sp" />
+
+    </RelativeLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:fontFamily="@font/shabnammedium"
+        android:textColor="@color/black"
+        android:paddingHorizontal="12dp"
+        android:text="پیشنهاد می‌کنیم جهت اجرای بهتر برنامه در پس‌زمینه، بهینه‌ساز باتری غیرفعال باشد." />
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="48dp"
+        android:gravity="center">
+
+        <TextView
+            android:id="@+id/battery_current_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:fontFamily="@font/shabnam"
+            android:layout_marginStart="18dp"
+            android:text="فعال است"
+            android:textSize="18sp"
+            android:textColor="#E4AB53" />
+
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="18dp"
+            android:textSize="18sp"
+            android:fontFamily="@font/shabnam"
+            android:text="وضعیت فعلی"
+            android:textColor="@color/black" />
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="48dp"
+        android:gravity="center">
+
+        <Button
+            android:id="@+id/battery_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/button_background"
+            android:text="غیرفعال‌سازی"
+            android:textSize="18sp"
+            android:textColor="@color/white"
+            android:fontFamily="@font/shabnam" />
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="10dp"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:layout_marginTop="36dp"
+        >
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="24dp"
+        android:gravity="center_horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/shabnammedium"
+            android:textColor="@color/black"
+            android:text="اگر دستگاه شما فرایند اتوماتیک را پشتیبانی نمی‌کند، می‌توانید با استفاده از راهنمای زیر بصورت دستی این کار را انجام دهید." />
+
+        <Button
+            android:id="@+id/battery_manual"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/button_background"
+            android:text="راهنما"
+            android:textSize="18sp"
+            android:textColor="@color/white"
+            android:fontFamily="@font/shabnam"
+            android:layout_marginTop="24dp" />
+
+    </LinearLayout>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -497,6 +497,74 @@
           android:textSize="16sp" />
 
       </LinearLayout>
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="10dp"
+          android:gravity="center"
+          android:orientation="vertical"
+          >
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray" />
+      </LinearLayout>
+
+      <LinearLayout
+          android:id="@+id/battery_layout"
+          android:layout_width="match_parent"
+          android:layout_height="80dp"
+          android:gravity="center"
+          android:layout_marginHorizontal="16dp"
+          android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+          <LinearLayout
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_weight="2"
+              >
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="start">
+
+              <TextView
+                  android:id="@+id/battery"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:fontFamily="@font/shabnam"
+                  android:text="مدیریت"
+                  android:textSize="20sp"
+                  android:textColor="#E4AB53" />
+
+            </LinearLayout>
+          </LinearLayout>
+
+          <TextView
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:minWidth="100dp"
+              android:fontFamily="@font/shabnam"
+              android:text="بهینه‌ساز باتری"
+              android:textColor="@color/black"
+              android:textSize="20sp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/shabnam"
+            android:text="جهت اجرای برنامه در پس‌زمینه"
+            android:textColor="#9A9A9A"
+            android:textSize="16sp" />
+
+      </LinearLayout>
     </LinearLayout>
   </ScrollView>
 


### PR DESCRIPTION
Changes Made:

1. Added a new section in the Settings page to navigate to the Battery Optimization Management page
2. Check the current state of battery optimization for the app on that page and show two possible states:
    If battery optimization is enabled, show the current state as "Enabled" and a button to disable it. Clicking this will request user permission to disable optimization.
    If battery optimization is disabled, show the current state as "Disabled" and a button to enable optimization. Clicking this will direct the user to the battery usage settings to manually select their preferred setting. (An app cannot automatically re-enable optimization itself)
3. Included a "Help" section with a button linking to https://dontkillmyapp.com/, since different manufacturer skins can cause the automatic process to not work properly. This site provides instructions for users to manually disable battery optimization on their specific device.

However, it is important to note that use of REQUEST_IGNORE_BATTERY_OPTIMIZATIONS violates Google Play's policy unless it is absolutely necessary:
https://developer.android.com/training/monitoring-device-state/doze-standby.html

When uploading the app to the Play Store, they will ask why this permission is required. A justification will need to be provided detailing why battery optimization must be disabled for the VPN to function properly.

![Screenshot_20240227_113057](https://github.com/bepass-org/oblivion/assets/160499835/40397248-f859-48b8-9338-aa9b9a139e75)
![Screenshot_20240227_113126](https://github.com/bepass-org/oblivion/assets/160499835/6b28f7e8-278e-4ad7-a4f0-ae82d0613539)
![Screenshot_20240227_113147](https://github.com/bepass-org/oblivion/assets/160499835/8b9e0b83-bbde-449f-a32d-53449ed63db8)
