### PR TITLE
Fix issues with EditSheet input validation

### DIFF
--- a/app/src/main/java/org/bepass/oblivion/EditSheet.java
+++ b/app/src/main/java/org/bepass/oblivion/EditSheet.java
@@ -1,11 +1,15 @@
 package org.bepass.oblivion;
 
 import android.content.Context;
+import android.text.InputType;
+import android.text.method.DigitsKeyListener;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
 import com.google.android.material.bottomsheet.BottomSheetDialog;
+
+import java.util.Objects;
 
 public class EditSheet {
 
@@ -57,13 +61,20 @@ public class EditSheet {
             return;
         }
 
+        if(Objects.equals(sharedPrefKey, "port")) {
+            value.setInputType(InputType.TYPE_CLASS_NUMBER);
+            value.setKeyListener(DigitsKeyListener.getInstance());
+        }
+
         titleView.setText(title);
         value.setText(fileManager.getString("USERSETTING_" + sharedPrefKey));
 
         cancel.setOnClickListener(v -> sheet.cancel());
         apply.setOnClickListener(v -> {
-            fileManager.set("USERSETTING_" + sharedPrefKey, value.getText().toString());
-            sheet.cancel();
+            if(!value.getText().toString().equals("") || Objects.equals(sharedPrefKey, "license")){
+                fileManager.set("USERSETTING_" + sharedPrefKey, value.getText().toString());
+                sheet.cancel();
+            }
         });
 
         sheet.show();


### PR DESCRIPTION
This PR fixes some issues around input validation in the EditSheet bottom sheet:

- The port EditText now only allows numeric input  
- Added check to prevent saving empty endpoint/port prefs

These changes validate user input better and prevent bugs.

Previously, endpoint and port prefs could be saved as empty values. This caused crashes and bugs in the app.

Overall, these changes improve input validation and prevent bugs from incorrect or empty data being stored.