### PR TITLE
Add Play store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ It's leveraging `bepass-sdk` and a custom Go implementation of WireGuard, it's d
 
 ## Quick Start
 
-1. **Download**: Grab the APK from our [Releases](https://github.com/bepass-org/oblivion/releases) page.
-2. **Install**: Open the APK file to install.
-3. **Connect**: Launch Oblivion and hit the switch button.
+1. **Download**: Grab the APK from our [Releases](https://github.com/bepass-org/oblivion/releases) page or [Google play store](https://play.google.com/store/apps/details?id=org.bepass.oblivion) and install it.
+<a href="https://play.google.com/store/apps/details?id=org.bepass.oblivion">
+<img alt="Get it on Google Play" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" width="165" height="64" />
+</a>
+
+2. **Connect**: Launch Oblivion and hit the switch button.
 
 ## Building the Project
 


### PR DESCRIPTION
Now, grabing the apk is not the only way of installing oblivion. I added the play store link, so users can install and update the app easier.