### PR TITLE
Refactor onStartCommand method to use switch statement for action handling

### DIFF
--- a/app/src/main/java/org/bepass/oblivion/OblivionVpnService.java
+++ b/app/src/main/java/org/bepass/oblivion/OblivionVpnService.java
@@ -365,16 +365,18 @@ public class OblivionVpnService extends VpnService {
             return START_NOT_STICKY;
         }
 
-        if (action.equals(FLAG_VPN_START)) {
-            start();
-            return START_STICKY;
-        }
+        switch (action) {
+            case FLAG_VPN_START:
+                start();
+                return START_STICKY;
 
-        if (action.equals(FLAG_VPN_STOP)) {
-            onRevoke();
-            return START_NOT_STICKY;
+            case FLAG_VPN_STOP:
+                onRevoke();
+                return START_NOT_STICKY;
+
+            default:
+                return START_NOT_STICKY;
         }
-        return START_NOT_STICKY;
     }
 
     @Override


### PR DESCRIPTION
Refactor `onStartCommand` method in `OblivionVpnService` for improved action handling.

This refactor replaces multiple `if-else` statements with a `switch` statement, enhancing readability and maintainability by centralizing Intent action dispatching for starting and stopping the VPN service (`FLAG_VPN_START` and `FLAG_VPN_STOP`).

Key Changes:
- Simplified action handling logic using a `switch` statement.
- Ensured compatibility with existing functionality.
- Thoroughly tested for correct behavior with various Intent actions.